### PR TITLE
[WIP] Change port check method

### DIFF
--- a/clicrud/device/generic/ver/base/__init__.py
+++ b/clicrud/device/generic/ver/base/__init__.py
@@ -42,10 +42,10 @@ class telnet(object):
 
         _args.update(_t_args)
 
-        # PEP8 fix
-        # if _args.has_key('port'):
-        if "port" in _args:
-            pass
+        # Check for port value. If it doesn't exist, or is None, default to 23
+        if _args.get('port'):
+            if _args['port'] is None:
+                _args['port'] = 23
         else:
             _args['port'] = 23
 
@@ -462,9 +462,10 @@ class ssh(object):
 
         _args.update(_t_args)
 
-        # Check for port value. If it doesn't exist, default to 22
-        if "port" in _args:
-            pass
+        # Check for port value. If it doesn't exist, or is None, default to 22
+        if _args.get('port'):
+            if _args['port'] is None:
+                _args['port'] = 22
         else:
             _args['port'] = 22
 


### PR DESCRIPTION
What do you think of this change? I'm changing the code for over-riding the default port method to handle the situation where "port=None" is passed in as an argument.

I'm writing an ST2 pack for this library, and in that I set the port parameter as required: false. If I don't specify it, it passes in port: None as an argument. That causes problems for clicrud. This change looks for port in the args, _and_ checks to see if it is "None". Otherwise it defaults to 22/23.

If you don't like this, I can modify my ST2 action to handle it. Thoughts?
