### PR TITLE
ICX page break fix

### DIFF
--- a/clicrud/device/generic/__init__.py
+++ b/clicrud/device/generic/__init__.py
@@ -39,6 +39,10 @@ class generic(object):
         if self._transport.connected:
             return True
 
+    def read_icx(self, command, **kwargs):
+        _args = kwargs
+        return self._transport.read_icx(command, **_args)
+
     def read(self, command, **kwargs):
         _args = kwargs
         return self._transport.read(command, **_args)

--- a/clicrud/device/generic/ver/base/__init__.py
+++ b/clicrud/device/generic/ver/base/__init__.py
@@ -608,6 +608,18 @@ class ssh(object):
                         _block = False
         return _output
 
+    def read_icx(self, command, **kwargs):
+            self.client_conn.send("\n")
+            self._hostname = self.blocking_recv('#')
+            self._hostname = self._hostname.translate(None, '\r\n')
+
+            # Let's figure out what our new prompt looks like
+            self.client_conn.send("%s\r\n" % "enable")
+            self._config_hostname = self.blocking_recv("#")
+            self.client_conn.send("skip-page-display")
+            self.client_conn.send("\n")
+            return self.read(command, **kwargs)
+
     def read(self, command, **kwargs):
             _args = kwargs
             _returnlist = []


### PR DESCRIPTION
Added skip-page-display setting for ICX switches as due to long output it was getting hung to run commands like "show interfaces brief" to read details.
